### PR TITLE
Fix for `activerecord-mysql-awesome` friendly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ rvm:
   - 2.2
 env:
   - "AR_VERSION=3.2.21"
-  - "AR_VERSION=4.0.12"
-  - "AR_VERSION=4.1.8"
+  - "AR_VERSION=4.0.13"
+  - "AR_VERSION=4.1.9"
   - "AR_VERSION=4.2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
 env:
   - "AR_VERSION=3.2.21"
   - "AR_VERSION=4.0.12"
   - "AR_VERSION=4.1.8"
-  - "AR_VERSION=4.2.0.beta4"
+  - "AR_VERSION=4.2.0"

--- a/lib/activerecord-mysql-unsigned/active_record/v3/connection_adapters/abstract/schema_creation.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v3/connection_adapters/abstract/schema_creation.rb
@@ -4,6 +4,12 @@ module ActiveRecord
       class SchemaCreation # :nodoc:
         def initialize(conn)
           @conn = conn
+          @cache = {}
+        end
+
+        def accept(o)
+          m = @cache[o.class] ||= "visit_#{o.class.name.split('::').last}"
+          send m, o
         end
 
         private

--- a/lib/activerecord-mysql-unsigned/active_record/v3/connection_adapters/abstract/schema_definitions.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v3/connection_adapters/abstract/schema_definitions.rb
@@ -3,7 +3,7 @@ require 'active_record/connection_adapters/abstract/schema_definitions'
 module ActiveRecord
   module ConnectionAdapters
     class ColumnDefinition
-      attr_accessor :sql_type, :unsigned, :first, :after
+      attr_accessor :sql_type, :auto_increment, :unsigned, :first, :after
 
       def sql_type
         base.type_to_sql(type.to_sym, limit, precision, scale, unsigned) rescue type

--- a/lib/activerecord-mysql-unsigned/active_record/v3/connection_adapters/abstract/schema_definitions.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v3/connection_adapters/abstract/schema_definitions.rb
@@ -3,7 +3,7 @@ require 'active_record/connection_adapters/abstract/schema_definitions'
 module ActiveRecord
   module ConnectionAdapters
     class ColumnDefinition
-      attr_accessor :unsigned, :first, :after
+      attr_accessor :sql_type, :unsigned, :first, :after
 
       def sql_type
         base.type_to_sql(type.to_sym, limit, precision, scale, unsigned) rescue type

--- a/lib/activerecord-mysql-unsigned/active_record/v3/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v3/connection_adapters/abstract_mysql_adapter.rb
@@ -38,6 +38,21 @@ module ActiveRecord
         end
       end
 
+      class Column < ConnectionAdapters::Column # :nodoc:
+        attr_accessor :extra
+      end
+
+      def columns(table_name, name = nil) #:nodoc:
+        sql = "SHOW FULL FIELDS FROM #{quote_table_name(table_name)}"
+        execute_and_free(sql, 'SCHEMA') do |result|
+          each_hash(result).map do |field|
+            new_column(field[:Field], field[:Default], field[:Type], field[:Null] == "YES", field[:Collation]).tap do |column|
+              column.extra = field[:Extra]
+            end
+          end
+        end
+      end
+
       def schema_creation
         SchemaCreation.new self
       end

--- a/lib/activerecord-mysql-unsigned/active_record/v3/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v3/connection_adapters/abstract_mysql_adapter.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     class AbstractMysqlAdapter < AbstractAdapter
 
-      class TableDefinition
+      class PseudoTableDefinition
         def initialize(base)
           @base = base
         end
@@ -23,6 +23,7 @@ module ActiveRecord
           column.null        = options[:null]
           column.first       = options[:first]
           column.after       = options[:after]
+          column.auto_increment = options[:auto_increment]
           column
         end
 
@@ -42,7 +43,7 @@ module ActiveRecord
       end
 
       def create_table_definition(name, temporary, options)
-        TableDefinition.new self
+        PseudoTableDefinition.new self
       end
 
     end

--- a/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract/schema_definitions.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract/schema_definitions.rb
@@ -3,7 +3,7 @@ require 'active_record/connection_adapters/abstract/schema_definitions'
 module ActiveRecord
   module ConnectionAdapters
     class ColumnDefinition
-      attr_accessor :unsigned
+      attr_accessor :auto_increment, :unsigned
     end
 
     class TableDefinition
@@ -15,6 +15,7 @@ module ActiveRecord
       def new_column_definition(name, type, options)
         column = new_column_definition_without_unsigned(name, type, options)
         column.unsigned = options[:unsigned]
+        column.auto_increment = options[:auto_increment]
         column
       end
     end

--- a/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract_mysql_adapter.rb
@@ -49,6 +49,7 @@ module ActiveRecord
           elsif options[:after]
             sql << " AFTER #{quote_column_name(options[:after])}"
           end
+          sql
         end
 
         def type_to_sql(type, limit, precision, scale, unsigned = false)

--- a/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract_mysql_adapter.rb
@@ -29,8 +29,8 @@ module ActiveRecord
         end
 
         def visit_ColumnDefinition(o)
-          sql_type = type_to_sql(o.type.to_sym, o.limit, o.precision, o.scale, o.unsigned)
-          column_sql = "#{quote_column_name(o.name)} #{sql_type}"
+          o.sql_type = type_to_sql(o.type.to_sym, o.limit, o.precision, o.scale, o.unsigned)
+          column_sql = "#{quote_column_name(o.name)} #{o.sql_type}"
           add_column_options!(column_sql, column_options(o)) unless o.type.to_sym == :primary_key
 
           column_sql

--- a/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract_mysql_adapter.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module ConnectionAdapters
     class AbstractMysqlAdapter < AbstractAdapter
  
-      class ChangeColumnDefinition < Struct.new(:column, :type, :options) #:nodoc:
+      class ChangeColumnDefinition < Struct.new(:column, :name) #:nodoc:
       end
 
       class SchemaCreation < AbstractAdapter::SchemaCreation
@@ -12,16 +12,7 @@ module ActiveRecord
           add_column_position!("ADD #{accept(o)}", column_options(o))
         end
 
-        def visit_ChangeColumnDefinition(o)
-          column = o.column
-          options = o.options
-          sql_type = type_to_sql(o.type, options[:limit], options[:precision], options[:scale], options[:unsigned])
-          change_column_sql = "CHANGE #{quote_column_name(column.name)} #{quote_column_name(options[:name])} #{sql_type}"
-          add_column_options!(change_column_sql, options.merge(column: column)) unless o.type.to_sym == :primary_key
-          add_column_position!(change_column_sql, options)
-
-          change_column_sql
-        end
+        private
 
         def visit_ColumnDefinition(o)
           o.sql_type = type_to_sql(o.type.to_sym, o.limit, o.precision, o.scale, o.unsigned)
@@ -29,6 +20,11 @@ module ActiveRecord
           add_column_options!(column_sql, column_options(o)) unless o.type.to_sym == :primary_key
 
           column_sql
+        end
+
+        def visit_ChangeColumnDefinition(o)
+          change_column_sql = "CHANGE #{quote_column_name(o.name)} #{accept(o.column)}"
+          add_column_position!(change_column_sql, column_options(o.column))
         end
 
         def column_options(o)
@@ -92,7 +88,7 @@ module ActiveRecord
       end
 
       def add_column_sql(table_name, column_name, type, options = {})
-        td = create_table_definition table_name, options[:temporary], options[:options]
+        td = create_table_definition(table_name, false, nil)
         cd = td.new_column_definition(column_name, type, options)
         schema_creation.visit_AddColumn cd
       end
@@ -108,8 +104,23 @@ module ActiveRecord
           options[:null] = column.null
         end
 
-        options[:name] = column.name
-        schema_creation.visit_ChangeColumnDefinition ChangeColumnDefinition.new column, type, options
+        td = create_table_definition(table_name, false, nil)
+        cd = td.new_column_definition(column.name, type, options)
+        schema_creation.accept(ChangeColumnDefinition.new(cd, column.name))
+      end
+
+      def rename_column_sql(table_name, column_name, new_column_name)
+        column  = column_for(table_name, column_name)
+        options = {
+          default: column.default,
+          null: column.null,
+          auto_increment: column.extra == "auto_increment"
+        }
+
+        current_type = select_one("SHOW COLUMNS FROM #{quote_table_name(table_name)} LIKE '#{column_name}'", 'SCHEMA')["Type"]
+        td = create_table_definition(table_name, false, nil)
+        cd = td.new_column_definition(new_column_name, current_type, options)
+        schema_creation.accept(ChangeColumnDefinition.new(cd, column.name))
       end
 
     end

--- a/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract_mysql_adapter.rb
@@ -35,6 +35,7 @@ module ActiveRecord
           column_options = super
           column_options[:first] = o.first
           column_options[:after] = o.after
+          column_options[:auto_increment] = o.auto_increment
           column_options
         end
 

--- a/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-unsigned/active_record/v4/connection_adapters/abstract_mysql_adapter.rb
@@ -9,12 +9,7 @@ module ActiveRecord
 
       class SchemaCreation < AbstractAdapter::SchemaCreation
         def visit_AddColumn(o)
-          sql_type = type_to_sql(o.type.to_sym, o.limit, o.precision, o.scale, o.unsigned)
-          add_column_sql = "ADD #{quote_column_name(o.name)} #{sql_type}"
-          add_column_options!(add_column_sql, column_options(o)) unless o.type.to_sym == :primary_key
-          add_column_position!(add_column_sql, column_options(o))
-
-          add_column_sql
+          add_column_position!("ADD #{accept(o)}", column_options(o))
         end
 
         def visit_ChangeColumnDefinition(o)

--- a/spec/support/migrations.rb
+++ b/spec/support/migrations.rb
@@ -61,6 +61,7 @@ end
 class AddColumnToUsersTable < ActiveRecord::Migration
   def self.change
     add_column    :users, :added_unsigned_int, :integer, unsigned: true
+    rename_column :users, :added_unsigned_int, :renamed_unsigned_int
   end
 end
 

--- a/spec/unsigned_spec.rb
+++ b/spec/unsigned_spec.rb
@@ -28,16 +28,21 @@ describe "INT/Decimal column" do
   end
 
   it "not allowed minus value of unsigned int" do
-    @user.unsigned_int = -2147483648
 
     if strict_mode?
       begin
+        @user.unsigned_int = -2147483648
         @user.save
         expect(true).to be_falsey # should not be reached here
       rescue => e
-        expect(e).to be_an_instance_of ActiveRecord::StatementInvalid
+        if ActiveRecord::VERSION::STRING < "4.2.0"
+          expect(e).to be_an_instance_of ActiveRecord::StatementInvalid
+        else
+          expect(e).to be_an_instance_of RangeError
+        end
       end
     else
+      @user.unsigned_int = -2147483648
       @user.save
       @user.reload
       expect(@user.unsigned_int).to be 0 # saved 0


### PR DESCRIPTION
https://github.com/waka/activerecord-mysql-unsigned/pull/23 will break `rename_column_sql`.

And, there are some points which concern me in https://github.com/waka/activerecord-mysql-unsigned/pull/23:
- `ChangeColumnDefinition` is used by `change_column_sql` and `rename_column_sql`.
  - When changing the structure of `ChangeColumnDefinition`, it's necessary to modify both methods.
- The arity of `visit_ChangeColumnDefinition` shouldn't be changed.
  - Basically, `visit_XxxDefinition` is called by `SchemaCreation#accept`, the argument is passed a `XxxDefinition` instance.
- It's better to handle `:auto_increment` option in `SchemaCreation#column_options`.

IMO, it wasn't necessary to use [activerecord-mysql-awesome](https://github.com/kamipo/activerecord-mysql-awesome) with [activerecord-mysql-unsigned](https://github.com/waka/activerecord-mysql-unsigned).
Could you tell me why want to use with it please?
